### PR TITLE
[COMMON] [KAN-60] 백엔드 API와 연결을 위한 공통 Retrofit ApiClient 컴포넌트 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,6 +7,15 @@ android {
     compileSdk 31
 
     defaultConfig {
+        def localProperties = new Properties()
+        def localPropertiesFile = rootProject.file('local.properties')
+        if (localPropertiesFile.exists()) {
+            localPropertiesFile.withInputStream {
+                localProperties.load(it)
+            }
+        }
+
+        buildConfigField "String", "BASE_IP_ADDRESS", "\"${localProperties['base_ip_address']}\""
         applicationId "com.innerpeace.themoonha"
         minSdk 21
         targetSdk 31

--- a/app/src/main/java/com/innerpeace/themoonha/Constants.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/Constants.kt
@@ -1,0 +1,5 @@
+package com.innerpeace.themoonha
+
+object Constants {
+    val url = "http://${BuildConfig.BASE_IP_ADDRESS}:8080"
+}

--- a/app/src/main/java/com/innerpeace/themoonha/data/network/ApiClient.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/data/network/ApiClient.kt
@@ -1,0 +1,20 @@
+package com.innerpeace.themoonha.data.network
+
+import com.innerpeace.themoonha.Constants.url
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.converter.scalars.ScalarsConverterFactory
+
+object ApiClient {
+    fun getClient(): Retrofit = createRetrofit()
+
+    private fun createRetrofit(): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(url)
+            .client(OkHttpClient.Builder().build())
+            .addConverterFactory(ScalarsConverterFactory.create())
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+}


### PR DESCRIPTION
# 💡 PR 요약
백엔드 API와 연결을 위한 공통 Retrofit ApiClient 컴포넌트 구현했습니다.

## ⭐️ 관련 이슈
- closes : #22 

## 📍 작업한 내용
- 백엔드 API와 연결을 위한 공통 Retrofit ApiClient 컴포넌트 구현

## 🔎 결과 및 이슈 공유
노션 정보보호시트에 기재해둔 network_security_config.xml, local.properties 파일 내용 확인하시고 사용하시면 됩니다!

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
