### PR TITLE
[SCHEDULE] [KAN-34] 다음 스케줄 보기 구현

### DIFF
--- a/app/src/main/java/com/innerpeace/themoonha/data/model/lounge/LoungeHomeResponse.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/data/model/lounge/LoungeHomeResponse.kt
@@ -26,7 +26,8 @@ data class LoungeHomeResponse(
         val tutorId: Int,
         val tutorName: String,
         val tutorImgUrl: String,
-        val summary: String
+        val summary: String,
+        val permissionYn: Boolean
     )
 
     data class LoungeNoticePost(
@@ -44,7 +45,8 @@ data class LoungeHomeResponse(
         val noticeYn: Boolean,
         val loungePostImgList: List<String>,
         val createdAt: String,
-        val loungeMember: LoungeMember
+        val loungeMember: LoungeMember,
+        val permissionYn: Boolean
     )
 
     data class Attendance(

--- a/app/src/main/java/com/innerpeace/themoonha/data/model/lounge/LoungePostResponse.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/data/model/lounge/LoungePostResponse.kt
@@ -22,14 +22,16 @@ data class LoungePostResponse(
         val noticeYn: Boolean,
         val loungePostImgList: List<String>,
         val createdAt: String,
-        val loungeMember: LoungeMember
+        val loungeMember: LoungeMember,
+        val permissionYn: Boolean
     )
 
     data class LoungeComment(
         val loungeCommentId: Long,
         val content: String,
         val createdAt: String,
-        val loungeMember: LoungeMember
+        val loungeMember: LoungeMember,
+        val permissionYn: Boolean
     )
 
     data class LoungeMember(

--- a/app/src/main/java/com/innerpeace/themoonha/data/model/schedule/ScheduleNextResponse.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/data/model/schedule/ScheduleNextResponse.kt
@@ -1,0 +1,26 @@
+package com.innerpeace.themoonha.data.model.schedule
+
+/**
+ * 다음 스케줄 응답 DTO
+ * @author 조희정
+ * @since 2024.09.09
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.09.09  	조희정       최초 생성
+ * </pre>
+ */
+data class ScheduleNextResponse (
+    val lessonId: Long,
+    val branchName: String,
+    val lessonTitle: String,
+    val cnt: Int,
+    val period: String,
+    val lessonTime: String,
+    val tutorName: String,
+    val target: String,
+    val loungeId: Long,
+    val onlineYn: Boolean
+)

--- a/app/src/main/java/com/innerpeace/themoonha/data/network/ScheduleService.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/data/network/ScheduleService.kt
@@ -1,6 +1,7 @@
 package com.innerpeace.themoonha.data.network
 
 import com.innerpeace.themoonha.data.model.schedule.ScheduleMonthlyResponse
+import com.innerpeace.themoonha.data.model.schedule.ScheduleNextResponse
 import com.innerpeace.themoonha.data.model.schedule.ScheduleWeeklyResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -17,6 +18,7 @@ import retrofit2.http.Query
  * 2024.09.07  	조희정       최초 생성
  * 2024.09.07  	조희정       주간 스케줄 불러오기 구현
  * 2024.09.08  	조희정       월간 스케줄 불러오기 구현
+ * 2024.09.09  	조희정       다음 스케줄 불러오기 구현
  * </pre>
  */
 interface ScheduleService {
@@ -26,4 +28,7 @@ interface ScheduleService {
 
     @GET("schedule/monthly")
     suspend fun getScheduleMonthly(@Query("yearMonth") yearMonth: String): List<ScheduleMonthlyResponse>
+
+    @GET("schedule/next")
+    suspend fun getScheduleNext(): ScheduleNextResponse
 }

--- a/app/src/main/java/com/innerpeace/themoonha/data/repository/ScheduleRepository.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/data/repository/ScheduleRepository.kt
@@ -2,6 +2,7 @@ package com.innerpeace.themoonha.data.repository
 
 import android.util.Log
 import com.innerpeace.themoonha.data.model.schedule.ScheduleMonthlyResponse
+import com.innerpeace.themoonha.data.model.schedule.ScheduleNextResponse
 import com.innerpeace.themoonha.data.model.schedule.ScheduleWeeklyResponse
 import com.innerpeace.themoonha.data.network.ScheduleService
 
@@ -17,6 +18,7 @@ import com.innerpeace.themoonha.data.network.ScheduleService
  * 2024.09.07  	조희정       최초 생성
  * 2024.09.07  	조희정       주간 스케줄 불러오기 구현
  * 2024.09.08  	조희정       월간 스케줄 불러오기 구현
+ * 2024.09.08  	조희정       다음 스케줄 불러오기 구현
  * </pre>
  */
 class ScheduleRepository(private val scheduleService: ScheduleService) {
@@ -37,6 +39,16 @@ class ScheduleRepository(private val scheduleService: ScheduleService) {
             scheduleService.getScheduleMonthly(yearMonth)
         } catch (e: Exception) {
             Log.e("월간 스케줄 목록 조회 응답 실패", "${e.message}", e)
+            null
+        }
+    }
+
+    // 다음 스케줄 불러오기
+    suspend fun fetchScheduleNext(): ScheduleNextResponse? {
+        return try {
+            scheduleService.getScheduleNext()
+        } catch (e: Exception) {
+            Log.e("다음 스케줄 조회 응답 실패", "${e.message}", e)
             null
         }
     }

--- a/app/src/main/java/com/innerpeace/themoonha/ui/fragment/schedule/ScheduleMonthlyFragment.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/ui/fragment/schedule/ScheduleMonthlyFragment.kt
@@ -156,7 +156,7 @@ class ScheduleMonthlyFragment : Fragment() {
 
                         // 수업이 있으면 다이얼로그
                         if (eventsForDay.isNotEmpty()) {
-                            showLessonModal(eventsForDay)
+                            showLessonModal(eventsForDay, day)
                         }
                     }
                 }
@@ -280,12 +280,14 @@ class ScheduleMonthlyFragment : Fragment() {
     }
 
     // 강좌 상세정보 다이얼로그
-    private fun showLessonModal(eventsForDay: List<ScheduleMonthlyResponse>) {
+    private fun showLessonModal(eventsForDay: List<ScheduleMonthlyResponse>, day: CalendarDay) {
 
         val bottomSheetDialog = BottomSheetDialog(requireContext())
         val dialogBinding = DialogLessonInfoBinding.inflate(layoutInflater)
         val dialogAdapter = ScheduleDialogAdapter(eventsForDay)
         dialogBinding.vpLessonOfDay.adapter = dialogAdapter
+        val formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일", Locale.getDefault())
+        dialogBinding.tvSelectedDate.text = "${day.date.format(formatter)}일의 강좌"
 
         // 인디케이터 연결
         dialogBinding.vpScheduleDotsIndicator.setViewPager2(dialogBinding.vpLessonOfDay)

--- a/app/src/main/java/com/innerpeace/themoonha/viewModel/ScheduleViewModel.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/viewModel/ScheduleViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.innerpeace.themoonha.data.model.schedule.ScheduleMonthlyResponse
+import com.innerpeace.themoonha.data.model.schedule.ScheduleNextResponse
 import com.innerpeace.themoonha.data.model.schedule.ScheduleWeeklyResponse
 import com.innerpeace.themoonha.data.repository.ScheduleRepository
 import kotlinx.coroutines.launch
@@ -22,6 +23,7 @@ import kotlinx.coroutines.launch
  * 2024.09.07  	조희정       최초 생성
  * 2024.09.07  	조희정       주간 스케줄 불러오기 구현
  * 2024.09.08  	조희정       월간 스케줄 불러오기 구현
+ * 2024.09.08  	조희정       다음 스케줄 불러오기 구현
  * </pre>
  */
 class ScheduleViewModel(private val scheduleRepository: ScheduleRepository): ViewModel() {
@@ -41,6 +43,11 @@ class ScheduleViewModel(private val scheduleRepository: ScheduleRepository): Vie
     // 월간 스케줄 기준일
     private val _selectedYearMonth = MutableLiveData<String>()
     val selectedYearMonth: LiveData<String> get() = _selectedYearMonth
+
+    // 다음 스케줄
+    private val _scheduleNext = MutableLiveData<ScheduleNextResponse>()
+    val scheduleNext: LiveData<ScheduleNextResponse> get() = _scheduleNext
+
 
     fun setSelectedStandardDates(standardDates: List<String>) {
         _selectedStandardDate.value = standardDates
@@ -70,6 +77,17 @@ class ScheduleViewModel(private val scheduleRepository: ScheduleRepository): Vie
                 _scheduleMonthlyList.postValue(response)
             } catch (e: Exception) {
                 _scheduleMonthlyList.postValue(null)
+            }
+        }
+    }
+
+    fun fetchScheduleNext() {
+        viewModelScope.launch {
+            try {
+                val response = scheduleRepository.fetchScheduleNext()
+                _scheduleNext.postValue(response)
+            } catch (e: Exception) {
+                _scheduleNext.postValue(null)
             }
         }
     }

--- a/app/src/main/res/layout/dialog_lesson_info.xml
+++ b/app/src/main/res/layout/dialog_lesson_info.xml
@@ -7,6 +7,16 @@
         android:orientation="vertical"
         android:padding="16dp">
 
+    <TextView
+            android:id="@+id/tv_selected_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="2024년 8월 23일의 강좌"
+            android:textColor="@color/black"
+            android:textSize="12sp"
+            android:layout_marginLeft="8dp"
+            android:visibility="visible"/>
+
     <androidx.viewpager2.widget.ViewPager2
             android:id="@+id/vp_lesson_of_day"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_schedule.xml
+++ b/app/src/main/res/layout/fragment_schedule.xml
@@ -25,7 +25,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tv_next_lesson" />
+            app:layout_constraintTop_toBottomOf="@+id/tv_next_lesson"/>
 
     <LinearLayout
             android:id="@+id/tab"

--- a/app/src/main/res/layout/item_next_lesson.xml
+++ b/app/src/main/res/layout/item_next_lesson.xml
@@ -5,9 +5,19 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginVertical="4dp"
-        android:layout_marginHorizontal="4dp">
+        android:layout_marginHorizontal="4dp"
+        android:orientation="vertical">
+
+    <TextView
+            android:id="@+id/tv_no_lesson_today"
+            android:layout_width="match_parent"
+            android:layout_height="100dp"
+            android:text="오늘은 더이상 수업이 없습니다."
+            android:gravity="center"
+            android:visibility="gone"/>
 
     <androidx.cardview.widget.CardView
+                android:id="@+id/card_next_lesson"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:cardCornerRadius="15dp"


### PR DESCRIPTION
# 💡 PR 요약
다음 스케줄 보기 구현했습니다.

## ⭐️ 관련 이슈
- closes : #52 

## 📍 작업한 내용
- 오늘의 다음 강좌 보기

## 🔎 결과 및 이슈 공유
<img width="498" alt="image" src="https://github.com/user-attachments/assets/02047bea-65a6-48dd-9b6c-a7add399a50f">
<img width="498" alt="image" src="https://github.com/user-attachments/assets/5f131cd1-63be-4ea8-af03-3941030a276e">


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
