### PR TITLE
[LESSON] [KAN-59] 숏폼 상세 조회 시 첫번째 데이터만 불러오던 로직 해결

### DIFF
--- a/app/src/main/java/com/innerpeace/themoonha/adapter/ShortFormAdapter.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/adapter/ShortFormAdapter.kt
@@ -11,7 +11,7 @@ import com.innerpeace.themoonha.R
 import com.innerpeace.themoonha.data.model.lesson.ShortFormDTO
 
 class ShortFormAdapter( private var shortForms: List<ShortFormDTO>,
-                        private val onItemClicked: (ShortFormDTO) -> Unit
+                        private val onItemClicked: (ShortFormDTO, Int) -> Unit
 ) : RecyclerView.Adapter<ShortFormAdapter.ShortFormViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ShortFormViewHolder {
@@ -24,7 +24,7 @@ class ShortFormAdapter( private var shortForms: List<ShortFormDTO>,
         holder.bind(shortForm)
 
         holder.itemView.setOnClickListener {
-            onItemClicked(shortForm)
+            onItemClicked(shortForm, position)
         }
     }
 

--- a/app/src/main/java/com/innerpeace/themoonha/adapter/ShortFormDetailAdapter.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/adapter/ShortFormDetailAdapter.kt
@@ -3,6 +3,7 @@ package com.innerpeace.themoonha.adapter
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.animation.ObjectAnimator
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/java/com/innerpeace/themoonha/ui/fragment/lesson/LessonFragment.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/ui/fragment/lesson/LessonFragment.kt
@@ -94,8 +94,9 @@ class LessonFragment : Fragment() {
         })
         binding.recyclerViewLesson.adapter = lessonAdapter
 
-        shortFormAdapter = ShortFormAdapter(emptyList()) { shortForm ->
-            findNavController().navigate(R.id.action_fragment_lesson_to_shortFormDetailFragment)
+        shortFormAdapter = ShortFormAdapter(emptyList()) { shortForm, position ->
+            val bundle = bundleOf("selectedPosition" to position)
+            findNavController().navigate(R.id.action_fragment_lesson_to_shortFormDetailFragment, bundle)
         }
 
         binding.craftButton.setOnClickListener {

--- a/app/src/main/java/com/innerpeace/themoonha/ui/fragment/lesson/ShortFormDetailFragment.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/ui/fragment/lesson/ShortFormDetailFragment.kt
@@ -47,6 +47,9 @@ class ShortFormDetailFragment : Fragment() {
         viewModel.shortFormList.observe(viewLifecycleOwner) { shortForms ->
             adapter = ShortFormDetailAdapter(shortForms)
             viewPager.adapter = adapter
+
+            val selectedPosition = arguments?.getInt("selectedPosition") ?: 0
+            viewPager.setCurrentItem(selectedPosition, false)
         }
 
         viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {


### PR DESCRIPTION
# 💡 PR 요약
숏폼 상세 조회 시 첫번째 데이터만 불러오던 로직 해결

## ⭐️ 관련 이슈
- closes : #55 

## 📍 작업한 내용
- 숏폼 상세 조회 시 첫번째 데이터만 불러오던 로직 해결

## 🔎 결과 및 이슈 공유


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. 
