### PR TITLE
[COMMON] 로그인 페이지 구현 및 토큰 상태 유지

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,4 +87,6 @@ dependencies {
     implementation 'de.hdodenhof:circleimageview:3.1.0'
     implementation 'com.github.kizitonwose:CalendarView:1.0.4'
     implementation "com.kakao.sdk:v2-share:2.11.2"
+    implementation "com.squareup.okhttp3:okhttp-urlconnection:4.9.1"
+
 }

--- a/app/src/main/java/com/innerpeace/themoonha/SharedPreferencesManager.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/SharedPreferencesManager.kt
@@ -1,0 +1,41 @@
+package com.innerpeace.themoonha
+
+import android.content.Context
+import android.content.SharedPreferences
+
+class SharedPreferencesManager(context: Context) {
+    private val authSharedPreferences: SharedPreferences =
+        context.getSharedPreferences("AuthPrefs", Context.MODE_PRIVATE)
+
+    fun setIsLogin(isLogin: Boolean) {
+        with(authSharedPreferences.edit()) {
+            putBoolean("isLoggedIn", isLogin)
+            apply()
+        }
+    }
+
+    fun getIsLogin(): Boolean {
+        return authSharedPreferences.getBoolean("isLoggedIn", false)
+    }
+
+    fun clear() {
+        with(authSharedPreferences.edit()) {
+            clear()
+            apply()
+        }
+    }
+
+    fun setLoginToken(accessToken: String, refreshToken: String) {
+        with(authSharedPreferences.edit()) {
+            putString("accessToken", accessToken)
+            putString("refreshToken", refreshToken)
+            apply()
+        }
+    }
+
+    fun getLoginToken(): Pair<String?, String?> {
+        val accessToken = authSharedPreferences.getString("accessToken", null)
+        val refreshToken = authSharedPreferences.getString("refreshToken", null)
+        return Pair(accessToken, refreshToken)
+    }
+}

--- a/app/src/main/java/com/innerpeace/themoonha/adapter/ShortFormAdapter.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/adapter/ShortFormAdapter.kt
@@ -22,7 +22,6 @@ class ShortFormAdapter( private var shortForms: List<ShortFormDTO>,
     override fun onBindViewHolder(holder: ShortFormViewHolder, position: Int) {
         val shortForm = shortForms[position]
         holder.bind(shortForm)
-
         holder.itemView.setOnClickListener {
             onItemClicked(shortForm, position)
         }

--- a/app/src/main/java/com/innerpeace/themoonha/adapter/ShortFormDetailAdapter.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/adapter/ShortFormDetailAdapter.kt
@@ -17,6 +17,10 @@ import com.innerpeace.themoonha.data.model.lesson.ShortFormDTO
 class ShortFormDetailAdapter(private var shortForms: List<ShortFormDTO>) :
     RecyclerView.Adapter<ShortFormDetailAdapter.ShortFormDetailViewHolder>() {
 
+    fun getShortFormAt(position: Int): ShortFormDTO? {
+        return if (position in shortForms.indices) shortForms[position] else null
+    }
+
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int

--- a/app/src/main/java/com/innerpeace/themoonha/data/model/auth/LoginRequest.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/data/model/auth/LoginRequest.kt
@@ -1,0 +1,6 @@
+package com.innerpeace.themoonha.data.model.auth
+
+data class LoginRequest(
+    val username: String,
+    val password: String
+)

--- a/app/src/main/java/com/innerpeace/themoonha/data/network/ApiClient.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/data/network/ApiClient.kt
@@ -1,20 +1,90 @@
 package com.innerpeace.themoonha.data.network
 
+import android.content.Context
 import com.innerpeace.themoonha.Constants.url
+import com.innerpeace.themoonha.SharedPreferencesManager
+import okhttp3.Interceptor
+import okhttp3.JavaNetCookieJar
 import okhttp3.OkHttpClient
+import okhttp3.Response
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
+import java.net.CookieManager
 
 object ApiClient {
+    private lateinit var sharedPreferencesManager: SharedPreferencesManager
+
     fun getClient(): Retrofit = createRetrofit()
+
+    fun init(context: Context) {
+        sharedPreferencesManager = SharedPreferencesManager(context)
+    }
+
+    private fun createClient(): OkHttpClient {
+        return OkHttpClient.Builder()
+            .cookieJar(JavaNetCookieJar(CookieManager()))
+            .addInterceptor(CookieInterceptor(sharedPreferencesManager))
+            .addInterceptor(RequestInterceptor(sharedPreferencesManager))
+            .build()
+    }
 
     private fun createRetrofit(): Retrofit {
         return Retrofit.Builder()
             .baseUrl(url)
-            .client(OkHttpClient.Builder().build())
+            .client(createClient())
             .addConverterFactory(ScalarsConverterFactory.create())
             .addConverterFactory(GsonConverterFactory.create())
             .build()
+    }
+}
+
+class CookieInterceptor(private val sharedPreferencesManager: SharedPreferencesManager) :
+    Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val response = chain.proceed(request)
+
+        val cookies = response.headers("Set-Cookie")
+        if (cookies.isNotEmpty()) {
+            var accessToken: String? = null
+            var refreshToken: String? = null
+
+            for (cookie in cookies) {
+                val parsedCookie = cookie.split(";").map { it.trim() }
+
+                for (keyValue in parsedCookie) {
+                    when {
+                        keyValue.startsWith("accessToken=") -> accessToken = keyValue.substringAfter("accessToken=")
+                        keyValue.startsWith("refreshToken=") -> refreshToken =
+                            keyValue.substringAfter("refreshToken=")
+                    }
+                }
+            }
+
+            if (accessToken != null && refreshToken != null) {
+                sharedPreferencesManager.setLoginToken(accessToken, refreshToken)
+            }
+        }
+
+        return response
+    }
+}
+
+class RequestInterceptor(private val sharedPreferencesManager: SharedPreferencesManager) :
+    Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val requestBuilder = chain.request().newBuilder()
+
+        val (accessToken, refreshToken) = sharedPreferencesManager.getLoginToken()
+
+        if (!accessToken.isNullOrEmpty() && !refreshToken.isNullOrEmpty()) {
+            requestBuilder.addHeader("Cookie", "accessToken=$accessToken; refreshToken=$refreshToken")
+        } else {
+            sharedPreferencesManager.clear()
+            sharedPreferencesManager.setIsLogin(false)
+        }
+
+        return chain.proceed(requestBuilder.build())
     }
 }

--- a/app/src/main/java/com/innerpeace/themoonha/data/network/AuthService.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/data/network/AuthService.kt
@@ -1,0 +1,11 @@
+package com.innerpeace.themoonha.data.network
+
+import com.innerpeace.themoonha.data.model.auth.LoginRequest
+import com.innerpeace.themoonha.data.model.craft.CommonResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AuthService {
+    @POST("auth/login")
+    suspend fun login(@Body loginRequest: LoginRequest): CommonResponse
+}

--- a/app/src/main/java/com/innerpeace/themoonha/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/data/repository/AuthRepository.kt
@@ -1,0 +1,17 @@
+package com.innerpeace.themoonha.data.repository
+
+import android.util.Log
+import com.innerpeace.themoonha.data.model.auth.LoginRequest
+import com.innerpeace.themoonha.data.model.craft.CommonResponse
+import com.innerpeace.themoonha.data.network.AuthService
+
+class AuthRepository(private val authService: AuthService) {
+    suspend fun fetchLogin(loginRequest: LoginRequest): CommonResponse? {
+        return try {
+            authService.login(loginRequest)
+        } catch (e: Exception) {
+            Log.e("로그인 응답 실패", "${e.message}", e)
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/innerpeace/themoonha/ui/activity/common/MainActivity.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/ui/activity/common/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.core.content.ContextCompat
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
 import com.innerpeace.themoonha.R
+import com.innerpeace.themoonha.data.network.ApiClient
 import com.innerpeace.themoonha.databinding.ActivityMainBinding
 import com.kakao.sdk.common.KakaoSdk
 
@@ -31,6 +32,9 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        ApiClient.init(this)
+
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 

--- a/app/src/main/java/com/innerpeace/themoonha/ui/fragment/auth/SignInFragment.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/ui/fragment/auth/SignInFragment.kt
@@ -1,0 +1,75 @@
+package com.innerpeace.themoonha.ui.fragment.auth
+
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import com.innerpeace.themoonha.R
+import com.innerpeace.themoonha.SharedPreferencesManager
+import com.innerpeace.themoonha.data.model.auth.LoginRequest
+import com.innerpeace.themoonha.data.network.ApiClient
+import com.innerpeace.themoonha.data.network.AuthService
+import com.innerpeace.themoonha.data.repository.AuthRepository
+import com.innerpeace.themoonha.databinding.FragmentSignInBinding
+import kotlinx.coroutines.launch
+
+class SignInFragment : Fragment() {
+    private var mBinding : FragmentSignInBinding? = null
+    private val binding get() = mBinding!!
+    private val authRepository = AuthRepository(ApiClient.getClient().create(AuthService::class.java))
+    private lateinit var sharedPreferencesManager: SharedPreferencesManager
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val binding = FragmentSignInBinding.inflate(inflater, container, false)
+        sharedPreferencesManager = SharedPreferencesManager(requireContext().applicationContext)
+        mBinding = binding
+        return mBinding?.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.signInButton.setOnClickListener {
+            val loginId = binding.inputLoginId.text.toString()
+            val password = binding.inputPassword.text.toString()
+
+            if (loginId.isNotEmpty() && password.isNotEmpty()) {
+                login(loginId, password)
+            } else {
+                Toast.makeText(requireContext(), "아이디와 비밀번호를 입력하세요", Toast.LENGTH_SHORT).show()
+            }
+        }
+
+    }
+
+    private fun login(loginId: String, password: String) {
+        lifecycleScope.launch {
+            val loginRequest = LoginRequest(username = loginId, password = password)
+            val response = authRepository.fetchLogin(loginRequest)
+
+            if (response != null && response.success) {
+                sharedPreferencesManager.setIsLogin(true)
+                Log.i("shared : ", sharedPreferencesManager.getIsLogin().toString())
+                Log.i("shared : ", sharedPreferencesManager.getLoginToken().toString())
+                findNavController().navigate(R.id.action_signInFragment_to_fragment_lesson)
+            } else {
+                Toast.makeText(requireContext(), "로그인 실패", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        mBinding = null
+        super.onDestroyView()
+    }
+
+}

--- a/app/src/main/java/com/innerpeace/themoonha/ui/fragment/lesson/LessonDetailFragment.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/ui/fragment/lesson/LessonDetailFragment.kt
@@ -53,6 +53,7 @@ class LessonDetailFragment : Fragment() {
         _binding = FragmentLessonDetailBinding.inflate(inflater, container, false)
         val view = binding.root
         (activity as? MainActivity)?.hideNavigationBar()
+        activity?.findViewById<Toolbar>(R.id.toolbar)?.visibility = View.VISIBLE
         (activity as? MainActivity)?.setToolbarTitle("강좌 상세")
 
         return view
@@ -63,7 +64,7 @@ class LessonDetailFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         val lessonId = arguments?.getLong("lessonId") ?: return
-        Log.i("lessonId = ", lessonId.toString())
+        Log.i("lessonId : ", lessonId.toString())
         viewModel.getLessonDetail(lessonId)
 
         viewModel.lessonDetail.observe(viewLifecycleOwner, Observer { lessonDetail ->
@@ -155,6 +156,13 @@ class LessonDetailFragment : Fragment() {
     override fun onResume() {
         super.onResume()
         handler.postDelayed(videoPlayRunnable, 3000)
+        val shortFormDetailFragment = parentFragmentManager.findFragmentByTag("ShortFormDetailFragment") as? ShortFormDetailFragment
+        shortFormDetailFragment?.let {
+            val viewPager = it.binding.viewPager2
+            val currentPage = viewModel.currentPage
+            Log.i("currentPage : ", viewModel.currentPage.toString())
+            viewPager.setCurrentItem(currentPage, false)
+        }
     }
 
     override fun onPause() {

--- a/app/src/main/java/com/innerpeace/themoonha/ui/fragment/lesson/LessonFragment.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/ui/fragment/lesson/LessonFragment.kt
@@ -96,6 +96,7 @@ class LessonFragment : Fragment() {
 
         shortFormAdapter = ShortFormAdapter(emptyList()) { shortForm, position ->
             val bundle = bundleOf("selectedPosition" to position)
+            viewModel.setCurrentShortFormId(shortForm.lessonId)
             findNavController().navigate(R.id.action_fragment_lesson_to_shortFormDetailFragment, bundle)
         }
 

--- a/app/src/main/java/com/innerpeace/themoonha/ui/fragment/lesson/ShortFormDetailFragment.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/ui/fragment/lesson/ShortFormDetailFragment.kt
@@ -1,18 +1,22 @@
 package com.innerpeace.themoonha.ui.fragment.lesson
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.widget.PopupMenu
 import androidx.appcompat.widget.Toolbar
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.innerpeace.themoonha.R
+import com.innerpeace.themoonha.adapter.ShortFormAdapter
 import com.innerpeace.themoonha.adapter.ShortFormDetailAdapter
+import com.innerpeace.themoonha.data.model.lesson.ShortFormDTO
 import com.innerpeace.themoonha.data.network.ApiClient
 import com.innerpeace.themoonha.data.network.LessonService
 import com.innerpeace.themoonha.data.repository.LessonRepository
@@ -23,7 +27,7 @@ import com.innerpeace.themoonha.viewModel.factory.LessonViewModelFactory
 class ShortFormDetailFragment : Fragment() {
 
     private var _binding: FragmentShortFormDetailBinding? = null
-    private val binding get() = _binding!!
+    val binding get() = _binding!!
     private lateinit var adapter: ShortFormDetailAdapter
     private val viewModel: LessonViewModel by activityViewModels {
         LessonViewModelFactory(LessonRepository(ApiClient.getClient().create(LessonService::class.java)))
@@ -46,36 +50,41 @@ class ShortFormDetailFragment : Fragment() {
 
         viewModel.shortFormList.observe(viewLifecycleOwner) { shortForms ->
             adapter = ShortFormDetailAdapter(shortForms)
-            viewPager.adapter = adapter
+            binding.viewPager2.adapter = adapter
 
             val selectedPosition = arguments?.getInt("selectedPosition") ?: 0
             viewPager.setCurrentItem(selectedPosition, false)
+
+            binding.leftArrow.setOnClickListener {
+                findNavController().navigateUp()
+            }
+
+            binding.hamburgerMenu.setOnClickListener {
+                val popupMenu = PopupMenu(requireContext(), it)
+                popupMenu.inflate(R.menu.short_form_menu)
+
+                popupMenu.setOnMenuItemClickListener {
+                    val currentShortFormId = viewModel.currentShortFormId.value
+                    val bundle = bundleOf("lessonId" to currentShortFormId)
+                    findNavController().navigate(R.id.action_shortFormDetailFragment_to_lessonDetailFragment, bundle)
+                    true
+                }
+                popupMenu.show()
+            }
+
         }
 
         viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
                 super.onPageSelected(position)
-            }
-        })
-
-        binding.leftArrow.setOnClickListener {
-            findNavController().navigateUp()
-        }
-
-        binding.hamburgerMenu.setOnClickListener {
-            val popupMenu = PopupMenu(requireContext(), it)
-            popupMenu.inflate(R.menu.short_form_menu)
-            popupMenu.setOnMenuItemClickListener { menuItem ->
-                when (menuItem.itemId) {
-                    R.id.action_view_details -> {
-                        findNavController().navigate(R.id.action_shortFormDetailFragment_to_lessonDetailFragment)
-                        true
-                    }
-                    else -> false
+                viewModel.currentPage = position
+                Log.i("position : ", position.toString())
+                val selectedShortForm = adapter.getShortFormAt(position)
+                selectedShortForm?.lessonId?.let { lessonId ->
+                    viewModel.setCurrentShortFormId(lessonId)
                 }
             }
-            popupMenu.show()
-        }
+        })
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/innerpeace/themoonha/viewModel/LessonViewModel.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/viewModel/LessonViewModel.kt
@@ -22,6 +22,9 @@ class LessonViewModel(private val lessonRepository: LessonRepository) : ViewMode
     private val _shortFormList = MutableLiveData<List<ShortFormDTO>>()
     val shortFormList: LiveData<List<ShortFormDTO>> get() = _shortFormList
 
+    private val _currentShortFormId = MutableLiveData<Long>()
+    val currentShortFormId: LiveData<Long> get() = _currentShortFormId
+
     private val _memberName = MutableLiveData<String>()
     val memberName: LiveData<String> get() = _memberName
 
@@ -39,6 +42,8 @@ class LessonViewModel(private val lessonRepository: LessonRepository) : ViewMode
 
     private val _lessonEnroll = MutableLiveData<List<LessonEnrollResponse>>()
     val lessonEnroll: LiveData<List<LessonEnrollResponse>> get() = _lessonEnroll
+
+    var currentPage: Int = 0
 
     fun getLessonList(lessonListQueryMap: Map<String, String>) {
         viewModelScope.launch {
@@ -110,5 +115,9 @@ class LessonViewModel(private val lessonRepository: LessonRepository) : ViewMode
                 _lessonEnroll.value = it
             }
         }
+    }
+
+    fun setCurrentShortFormId(lessonId: Long) {
+        _currentShortFormId.value = lessonId
     }
 }

--- a/app/src/main/res/layout/fragment_lesson.xml
+++ b/app/src/main/res/layout/fragment_lesson.xml
@@ -14,7 +14,7 @@
                 android:id="@+id/branchName"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="천호점"
+                android:text="모든 지점"
                 android:textColor="@color/black"
                 android:textSize="30sp"
                 android:layout_marginLeft="20dp"

--- a/app/src/main/res/layout/fragment_lesson_item.xml
+++ b/app/src/main/res/layout/fragment_lesson_item.xml
@@ -4,6 +4,7 @@
                                    android:layout_width="350dp"
                                    android:layout_height="380dp"
                                    app:cardCornerRadius="15dp"
+                                   android:layout_gravity="center_horizontal"
                                    android:layout_marginBottom="15dp"
                                    app:cardElevation="4dp"
                                    android:padding="16dp">

--- a/app/src/main/res/layout/fragment_sign_in.xml
+++ b/app/src/main/res/layout/fragment_sign_in.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <TextView
+        android:id="@+id/titleSignIn"
+
+        android:layout_width="309dp"
+        android:layout_height="83dp"
+        android:layout_marginTop="50dp"
+
+        android:gravity="center"
+        android:text="더문하 로그인"
+        android:textColor="@color/black"
+        android:textSize="20sp"
+        android:textStyle="bold"
+
+
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <EditText
+        android:id="@+id/inputLoginId"
+
+        android:layout_width="300dp"
+        android:layout_height="48dp"
+        android:layout_marginTop="9dp"
+        android:paddingStart="17dp"
+
+        android:gravity="left|center_vertical"
+        android:inputType="text"
+        android:hint="ID"
+        android:textColorHint="@color/light_gray_1"
+        android:textSize="14sp"
+        android:maxLength="20"
+
+        android:background="@drawable/button_border_black"
+
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/titleSignIn" />
+
+    <EditText
+        android:id="@+id/inputPassword"
+
+        android:layout_width="300dp"
+        android:layout_height="48dp"
+        android:layout_marginTop="9dp"
+        android:paddingStart="17dp"
+
+        android:gravity="left|center_vertical"
+        android:inputType="textPassword"
+        android:hint="PASSWORD"
+        android:textColorHint="@color/light_gray_1"
+        android:textSize="14sp"
+        android:maxLength="20"
+
+        android:background="@drawable/button_border_black"
+
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/inputLoginId" />
+
+    <android.widget.Button
+        android:id="@+id/signInButton"
+
+        android:layout_width="300dp"
+        android:layout_height="50dp"
+
+        android:layout_marginTop="28dp"
+
+        android:background="@drawable/button_border_black"
+        android:gravity="center"
+        android:text="로그인"
+        android:textColor="@color/black"
+        android:textSize="15sp"
+        android:textAllCaps="false"
+
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/inputPassword" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/bottom_navigation.xml
+++ b/app/src/main/res/menu/bottom_navigation.xml
@@ -22,7 +22,7 @@
             android:icon="@drawable/ic_bite"
             android:paddingBottom="19dp" />
     <item
-            android:id="@+id/fragment_my_info"
+            android:id="@+id/signInFragment"
             android:title="내 정보"
             android:icon="@drawable/ic_my_info"
             android:paddingBottom="19dp" />

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -26,6 +26,9 @@
         <action
             android:id="@+id/action_fragment_lesson_to_cartContentFragment"
             app:destination="@id/cartContentFragment" />
+        <action
+            android:id="@+id/action_fragment_lesson_to_signInFragment"
+            app:destination="@id/signInFragment" />
     </fragment>
     <fragment
             android:id="@+id/fragment_schedule"
@@ -147,4 +150,12 @@
         android:id="@+id/cartContentFragment"
         android:name="com.innerpeace.themoonha.ui.fragment.lesson.CartContentFragment"
         android:label="CartContentFragment" />
+    <fragment
+        android:id="@+id/signInFragment"
+        android:name="com.innerpeace.themoonha.ui.fragment.auth.SignInFragment"
+        android:label="SignInFragment" >
+        <action
+            android:id="@+id/action_signInFragment_to_fragment_lesson"
+            app:destination="@id/fragment_lesson" />
+    </fragment>
 </navigation>


### PR DESCRIPTION
# 💡 PR 요약
로그인 페이지 구현 및 토큰 상태 유지

## ⭐️ 관련 이슈
- closes : #61 

## 📍 작업한 내용
- 로그인 페이지 구현
- SharedPreferences로 jwt 토큰 상태 유지

## 🔎 결과 및 

https://github.com/user-attachments/assets/eb543a63-73e2-4475-ad5a-8acf012dca11

이슈 공유


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. 
