### PR TITLE
[LIVE] [KAN-58] 실시간 방송 종료 화면 추가

### DIFF
--- a/app/src/main/java/com/innerpeace/themoonha/ui/fragment/live/LiveStreamingMainFragment.kt
+++ b/app/src/main/java/com/innerpeace/themoonha/ui/fragment/live/LiveStreamingMainFragment.kt
@@ -5,12 +5,15 @@ import android.content.res.Configuration
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.FrameLayout
+import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -169,6 +172,27 @@ class LiveStreamingMainFragment : Fragment() {
                 setupRemoteVideo(uid)
             }
         }
+
+        override fun onUserOffline(uid: Int, reason: Int) {
+            activity?.runOnUiThread {
+                showStreamEndedMessage()
+            }
+        }
+    }
+
+    private fun showStreamEndedMessage() {
+        binding.onAirPlayer.removeAllViews()
+        binding.onAirPlayer.setBackgroundColor(ContextCompat.getColor(requireContext(), android.R.color.black))
+        binding.onAirPlayer.addView(TextView(requireContext()).apply {
+            text = "방송이 종료되었습니다."
+            setTextColor(ContextCompat.getColor(requireContext(), android.R.color.white))
+            gravity = Gravity.CENTER
+            textSize = 20f
+            layoutParams = FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT
+            )
+        })
     }
 
     private fun setupLocalVideo() {


### PR DESCRIPTION
# 💡 PR 요약
실시간 방송 종료 화면 추가했습니다. 

## ⭐️ 관련 이슈
- closes : #95 

## 📍 작업한 내용
- 실시간 방송 종료 화면 추가

## 🔎 결과 및 이슈 공유


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. 
